### PR TITLE
Fuzzy string searching

### DIFF
--- a/lirr.py
+++ b/lirr.py
@@ -80,6 +80,7 @@ def getStationId(station):
         results = suffix_array.get_fuzzy_search_results(station)
         if len(results) == 0:
             print("Tried to find the station. Couldn't. Blaming you.")
+            sys.exit()
         elif len(results) == 1:
             print("Assuming you meant to type '%s' when you wrote '%s'" % \
                     (list(results)[0], station), file=sys.stderr)

--- a/lirr.py
+++ b/lirr.py
@@ -30,6 +30,7 @@ import json
 import os.path
 import sys
 import urllib2
+from suffixarray import SuffixArray
 from tabulate import tabulate
 
 def loadStations():
@@ -51,8 +52,13 @@ def writeStationList():
                         writeToFile(stations)
 
 def getStationId(station):
-    # load stations in as a dict from stations.txt
-    # Ex: {"Penn Station":"NYK"}
+    """
+    load stations in as a dict from stations.txt
+    Ex: {"Penn Station":"NYK"}
+
+    Uses a suffix array implementation for fuzzy string matching
+    """
+    suffix_array = SuffixArray()
     stations = {}
     stations = ast.literal_eval(open('stations.txt').read())
     # lowercase all station names in stations

--- a/suffixarray.py
+++ b/suffixarray.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+"""
+A module for working with suffix arrays. 
+
+Author: venantius
+https://github.com/venantius/takehome/blob/master/readyforzero/search/suffixarray.py
+License: Eclipse license
+"""
+
+import difflib
+
+class SuffixArray(object):
+    """
+    Suffix Array class. Ideal for fast fuzzy string matching
+    """
+    def __init__(self):
+        self.array = []
+        self.hashmap = {}
+
+    def insert(self, string):
+        """
+        Add a new string to the suffix array
+        """
+        for i in range(len(string)):
+            self.array.append(string[i:])
+            try:
+                self.hashmap[string[i:]].append(string)
+            except KeyError:
+                self.hashmap[string[i:]] = [string]
+        self.array = sorted(self.array)
+
+    def get_fuzzy_search_results(self, string):
+        """
+        Uses _fuzzy_search and matches results to the hashmap's keys
+        """
+        results = []
+        for result in self._fuzzy_search(string):
+            results.extend(self.hashmap[result])
+        return set(results)
+
+    def _fuzzy_search(self, string, position=0, array=None):
+        """
+        Approximate text search
+        """
+        if not array:
+            array = self.array
+
+        if len(array) == 0:
+            return array
+        elif len(array) == 1:
+            if difflib.SequenceMatcher(a=string, 
+                    b=array[0][:len(string)]).ratio() < 0.60:
+                return []
+            else:
+                return array
+        else:
+            start_point = array[0]
+            end_point = array[-1]
+            if len(start_point) > position and len(end_point) > position and \
+                    start_point[position] == end_point[position]:
+                return self._fuzzy_search(string, position + 1, array)
+            else:
+                length = len(array) / 2
+                left = self._fuzzy_search(string, position, array[:length])
+                right = self._fuzzy_search(string, position, array[length:])
+                return left + right

--- a/suffixarray.py
+++ b/suffixarray.py
@@ -51,7 +51,7 @@ class SuffixArray(object):
             return array
         elif len(array) == 1:
             if difflib.SequenceMatcher(a=string, 
-                    b=array[0][:len(string)]).ratio() < 0.60:
+                    b=array[0][:len(string)]).ratio() < 0.70:
                 return []
             else:
                 return array


### PR DESCRIPTION
This PR adds fuzzy string matching to the station matching. In practice, it looks like the the following:

If there are multiple matches:

```
(core-dev)[davidjarvis@ziz:lirr] 00:13:57 $ python lirr.py -s pens -d hicks
Couldn't autocomplete 'pens' - did you mean one of the following?
oceanside
hempstead gardens
country life press
speonk
glen street
queens village
penn station
kew gardens
```

If there's only a single match:

```
(core-dev)[davidjarvis@ziz:lirr] 00:06:59 $ python lirr.py -s penn -d hickb
Assuming you meant to type 'hicksville' when you wrote 'hickb'
Source departure times    Destination arrival times      Trip duration in minutes
------------------------  ---------------------------  --------------------------
12:14 AM                  12:59 AM                                             45
12:45 AM                  01:08 AM                                             44
01:08 AM                  02:01 AM                                             53
01:19 AM                  02:05 AM                                             46
```

Otherwise we stick with the original behavior, e.g.:

```
(core-dev)[davidjarvis@ziz:lirr] 00:14:12 $ python lirr.py -s penn -d hicks
Source departure times    Destination arrival times      Trip duration in minutes
------------------------  ---------------------------  --------------------------
12:14 AM                  12:59 AM                                             45
12:45 AM                  01:08 AM                                             44
01:08 AM                  02:01 AM                                             53
01:19 AM                  02:05 AM                                             46
(core-dev)[davidjarvis@ziz:lirr] 00:18:10 $ python lirr.py -s pennnnnns -d hicks
Tried to find the station. Couldn't. Blaming you.
```
